### PR TITLE
empty request data changed to request query to create sha512 of request

### DIFF
--- a/ipn_handler_server.py
+++ b/ipn_handler_server.py
@@ -1,6 +1,7 @@
 from flask import Flask, request
 import hmac
 import hashlib
+from urllib.parse import urlencode
 
 app = Flask(__name__)
 
@@ -9,7 +10,7 @@ SECRET = 'itsnotmine'
 def receive_ipn():
 	received_hmac = request.headers['Hmac'])
 	generated_hmac = hmac.new(key = bytearray(SECRET, 'utf-8'), 
-                              msg = request.get_data(), # raw POST data will be passed here
+                              msg = urlencode(request.form.to_dict()).encode('ascii'), # raw POST data will be passed here
                               digestmod = hashlib.sha512).hexdigest()
 	if received_hmac == generated_hmac:
    	  pass  # do your thing here, notify user, save txn in DB ...


### PR DESCRIPTION
I fix the bug when create sha512 of request query . msg param return none object but I use this library to fix it and recreate request query. 